### PR TITLE
add shell check

### DIFF
--- a/lib/spawn-command.js
+++ b/lib/spawn-command.js
@@ -4,10 +4,16 @@ var spawn = require('child_process').spawn;
 module.exports = function (command, options) {
   var file, args;
   if (process.platform === 'win32') {
-    file = 'cmd.exe';
-    args = ['/s', '/c', '"' + command + '"'];
-    options = util._extend({}, options);
-    options.windowsVerbatimArguments = true;
+     var shell = process.env['SHELL'];
+     if (shell !== void 0) {
+       file = shell;
+       args = ['-c', command];
+     } else {
+       file = 'cmd.exe';
+       args = ['/s', '/c', '"' + command + '"'];
+       options = util._extend({}, options);
+       options.windowsVerbatimArguments = true;
+     }
   }
   else {
     file = '/bin/sh';


### PR DESCRIPTION
If SHELL environment variable is defined on win32 then node is launched by some POSIX shell and child process should be spawned by that shell. 

This will allow correctly spawn processes in mingw, cygwin or similar shells. (related issue: https://github.com/kimmobrunfeldt/concurrently/issues/90)